### PR TITLE
Error lbl caracteres no correctos.

### DIFF
--- a/src/domino.ino
+++ b/src/domino.ino
@@ -900,8 +900,11 @@ int configPort(char id, char *cfg, char *name)
 	debug_write(ports[id].type);
 
 	if (name != NULL) {
-		for (i = 0; i < 5; i++)
-			eeprom_set_byte(EMPORTSLOT * id + i, name[i]);
+		for (i = 0; i < 5; i++) 
+if (ISVALIDCHAR(name[i])){
+eeprom_set_byte(EMPORTSLOT * id + i, name[i]);
+}
+             else eeprom_set_byte(EMPORTSLOT * id + i, 'x'); 
 	}
 
 	return true;


### PR DESCRIPTION
Evitar introducir caracteres no validos función lbl. (label).
